### PR TITLE
Issue #10 - Update clone.admin.inc

### DIFF
--- a/includes/clone.admin.inc
+++ b/includes/clone.admin.inc
@@ -294,7 +294,7 @@ function content_type_clone_create(array $values) {
   // Create new groups.
   if (module_exists('field_group')) {
     $groups = field_group_info_groups('node', $values['source_machine_name'], NULL, TRUE);
-    if (!empty($groups))
+    if (!empty($groups)) {
       foreach ($groups['form'] as $group) {
         $group->bundle = $values['target_machine_name'];
         field_group_group_save($group, $new = TRUE);


### PR DESCRIPTION
Fixing - ParseError: syntax error, unexpected '}', expecting end of file in system_block_view() (line 332 of /app/modules/content_type_clone/includes/clone.admin.inc).

@laryn 